### PR TITLE
changed flood function in stream-example, for loop to '<=' from '<' s…

### DIFF
--- a/examples/stream-example.js
+++ b/examples/stream-example.js
@@ -33,9 +33,7 @@ var trainStream = net.createTrainStream({
 flood(trainStream, xor);
 
 function flood(stream, data) {
-  for (var i = 0; i < data.length; i++) {
+  for (var i = 0; i <= data.length; i++) {
     stream.write(data[i]);
   }
-  // let it know we've reached the end of the data
-  stream.write(null);
 }


### PR DESCRIPTION
updated flood function in stream-example.js so that it will send a null chunk to trainstream.write(). This triggers finish event emitter in write. Original caused a nodejs stream3 error because nodejs object mode true doesn't allow for null data writing. 

Example would throw an error, but the change allows the for loop to send undefined to trainsteam.write, causing the chunk to be false triggering the finished event emitter.