### PR TITLE
Unique elements in array using Set

### DIFF
--- a/src/train-stream.js
+++ b/src/train-stream.js
@@ -162,16 +162,11 @@ export default class TrainStream extends Writable {
 
 /**
  *
- * http://stackoverflow.com/a/21445415/1324039
+ * https://gist.github.com/telekosmos/3b62a31a5c43f40849bb
  * @param arr
  * @returns {Array}
  */
 function uniques(arr) {
-  let a = [];
-  for (let i=0, l=arr.length; i<l; i++) {
-    if (a.indexOf(arr[i]) === -1 && arr[i] !== '') {
-      a.push(arr[i]);
-    }
-  }
-  return a;
+  // Sets cannot contain duplicate elements, which is what we want
+  return [...new Set(arr)];
 }


### PR DESCRIPTION
Just like a Set is defined in Mathematics, it has the same rules in JS. It cannot contain duplicate elements, because it wouldn't make sense.

The `let setFromArray = new Set([Iterable : Array])` creates a Set from an Array, thereby removing any duplicate elements.

If you pass that `setFromArray` to the spread operator, it creates an array of the keys of the set(keys here are the elements of the Set), which is what we want.

```js
[...new Set(collection)]
```

It takes care of empty elements (`''`) as well; since they are not allowed, they are automatically removed.

A JSPerf test to confirm improved speed: [Unique Array elements using Set](https://jsperf.com/unique-array-elements-using-set)

Cheers!