### PR TITLE
Use Browserify standalone option for browser build

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,4 @@ var brain = {
   utilities: utilities
 };
 
-if (typeof window !== 'undefined') {
-  window.brain = brain;
-} else {
-  module.exports = brain;
-}
+module.exports = brain;

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "test": "npm run test-base && npm run test-utilities",
     "test-experimental": "npm run test-recurrent-matrix && npm run test-recurrent && npm run test-utilities",
     "dist": "babel src --out-dir dist --source-maps",
-    "browser": "browserify ./index.js -p licensify -o browser.js",
-    "browser-min": "browserify ./index.js -p licensify -g uglifyify -o browser.min.js",
+    "browser": "browserify ./index.js -p licensify -o browser.js -s brain",
+    "browser-min": "browserify ./index.js -p licensify -s brain -g uglifyify -o browser.min.js",
     "make": "rm -fr ./dist && npm run dist && git add ./dist && npm run browser && npm run browser-min"
   },
   "main": "./index.js",


### PR DESCRIPTION
Browserify has a `standalone` flag which wraps the default export into a [universal module definition](https://github.com/umdjs/umd) or a global variable in the browser build. That way it works with all module loaders and the index file does not have to check for a window.

This also makes it possible to use Brain.js with Webpack out of the box (which I would like to support in my [Brain.js natural language classifier](https://github.com/mysamai/natural-brain)).