### PR TITLE
Add a small browser test and automated runner script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git+ssh://git@github.com/brainjs/brain.js.git"
   },
   "scripts": {
+    "test-browser": "testee test/browser/index.html --browsers firefox --reporter Spec",
     "test-base": "find ./test/base/ -name '*.js' | xargs mocha --compilers js:babel-core/register",
     "test-recurrent": "find ./test/recurrent/ -name '*.js' | xargs mocha --compilers js:babel-core/register",
     "test-rnn": "find ./test/recurrent/ -name 'rnn.js' | xargs mocha --compilers js:babel-core/register",
@@ -34,6 +35,7 @@
     "licensify": "^3.1.2",
     "mocha": "^3.0.2",
     "sinon": "^1.17.6",
+    "testee": "^0.7.0",
     "uglifyify": "^3.0.2"
   },
   "keywords": [

--- a/test/browser/browser.test.js
+++ b/test/browser/browser.test.js
@@ -1,0 +1,22 @@
+/* global describe, it, brain, assert */
+describe('Brain.js basic browser test', function () {
+  it('has the brain global variable with the things we expect', function () {
+    assert(window.brain);
+    assert(brain.NeuralNetwork);
+    assert(brain.NeuralNetworkGPU);
+  });
+
+  it('runs the NeuralNetwork example', function () {
+    var net = new brain.NeuralNetwork();
+
+    net.train([
+      { input: { r: 0.03, g: 0.7, b: 0.5 }, output: { black: 1 } },
+      { input: { r: 0.16, g: 0.09, b: 0.2 }, output: { white: 1 } },
+      { input: { r: 0.5, g: 0.5, b: 1.0 }, output: { white: 1 } }
+    ]);
+
+    var output = net.run({ r: 1, g: 0.4, b: 0 });
+
+    assert(output.white > output.black);
+  });
+});

--- a/test/browser/index.html
+++ b/test/browser/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Mocha</title>
+  <script src="//unpkg.com/mocha@^3.2.0/mocha.js"></script>
+  <script>mocha.setup('bdd');</script>
+  <link rel="stylesheet" href="//unpkg.com/mocha@^3.2.0/mocha.css">
+</head>
+<body onload="mocha.run()">
+  <div id="mocha"></div>
+  <script>
+    function assert(expr, msg) {
+      if (!expr) throw new Error(msg || 'failed');
+    }
+  </script>
+  <script src="../../browser.js"></script>
+  <script src="./browser.test.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This is a follow-up for #124 and adds a small browser Mocha test and automated test runner script which can be run (using Firefox) via `npm run test-browser`. It could be added to CI to make sure that the basic browser build is working.