### PR TITLE
Support NeuralNetwork.toFunction() when relu or leaky-relu is the activation function

### DIFF
--- a/src/neural-network.js
+++ b/src/neural-network.js
@@ -885,9 +885,9 @@ export default class NeuralNetwork {
         case 'sigmoid':
           return `1/(1+1/Math.exp(${result.join('')}))`;
         case 'relu':
-          return `(function () { var sum = ${result.join('')};(sum < 0 ? 0 : sum);})()`;
+          return `(function () { var sum = ${result.join('')}; return (sum < 0 ? 0 : sum);})()`;
         case 'leaky-relu':
-          return `(function () { var sum = ${result.join('')};(sum < 0 ? 0 : 0.01 * sum);})()`;
+          return `(function () { var sum = ${result.join('')}; return (sum < 0 ? 0 : 0.01 * sum);})()`;
         case 'tanh':
           return `Math.tanh(${result.join('')});`;
         default:

--- a/src/neural-network.js
+++ b/src/neural-network.js
@@ -885,9 +885,9 @@ export default class NeuralNetwork {
         case 'sigmoid':
           return `1/(1+1/Math.exp(${result.join('')}))`;
         case 'relu':
-          return `var sum = ${result.join('')};(sum < 0 ? 0 : sum);`;
+          return `(function () { var sum = ${result.join('')};(sum < 0 ? 0 : sum);})()`;
         case 'leaky-relu':
-          return `var sum = ${result.join('')};(sum < 0 ? 0 : 0.01 * sum);`;
+          return `(function () { var sum = ${result.join('')};(sum < 0 ? 0 : 0.01 * sum);})()`;
         case 'tanh':
           return `Math.tanh(${result.join('')});`;
         default:

--- a/src/neural-network.js
+++ b/src/neural-network.js
@@ -885,9 +885,15 @@ export default class NeuralNetwork {
         case 'sigmoid':
           return `1/(1+1/Math.exp(${result.join('')}))`;
         case 'relu':
-          return `(function () { var sum = ${result.join('')}; return (sum < 0 ? 0 : sum);})()`;
+          return `(function () { 
+                    var sum = ${result.join('')};
+                    return (sum < 0 ? 0 : sum);
+                  })()`;
         case 'leaky-relu':
-          return `(function () { var sum = ${result.join('')}; return (sum < 0 ? 0 : 0.01 * sum);})()`;
+          return `(function () {
+                    var sum = ${result.join('')}; 
+                    return (sum < 0 ? 0 : 0.01 * sum);
+                  })()`;
         case 'tanh':
           return `Math.tanh(${result.join('')});`;
         default:


### PR DESCRIPTION
Without the IIFE, calling toFunction() on a neural network with relu, or leaky-relu set as the activation function causes toFunction() to throw a "SyntaxError: Unexpected token var"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Author's Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code focuses on the main motivation and avoids scope creep.
- [ ] My code passes current tests and adds new tests where possible.
- [ ] My code is [SOLID](https://en.wikipedia.org/wiki/SOLID_(object-oriented_design)) and [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
- [x] I have updated the documentation as needed.

## Reviewer's Checklist:
- [ ] I kept my comments to the author positive, specific, and productive.
- [ ] I tested the code and didn't find any new problems.
- [ ] I think the motivation is good for the project.
- [ ] I think the code works to satisfies the motivation.
