### PR TITLE
Fix NaN error rate bug in RNNs.

### DIFF
--- a/src/recurrent/rnn.js
+++ b/src/recurrent/rnn.js
@@ -473,9 +473,9 @@ class RNN {
         const err = this.trainPattern(data[j], true);
         sum += err;
       }
-      error = sum / data.length;
+      error = sum / Math.max(data.length, 1);
 
-      if (isNaN(error)) throw new Error('network error rate is unexpected NaN, check network configurations and try again');
+      if (Number.isNaN(error)) throw new Error('network error rate is unexpected NaN, check network configurations and try again');
       if (log && (i % logPeriod === 0)) {
         log(`iterations: ${ i }, training error: ${ error }`);
       }


### PR DESCRIPTION
I changed the NaN check along with the error rate calculation. I tried this locally on my computer and it causes the RNNs to be much, much less buggy.

This minor change prevents the RNNs from having an error rate of Infinity and NaN. I know why it prevents the NaN error rate (no more dividing by zero), however as I am new to ML I'm not sure why. I think it might have to do with `Number.isNaN` genuinely checking for NaN ( and not returning true for strings, arrays, etc.), but I don't know for sure.

This is a minor change, so it shouldn't have much of an impact on the rest of the library. I saw it's results while running some neural nets locally on my machine. I don't have an amazing testing environment, but the results looked promising.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Author's Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code focuses on the main motivation and avoids scope creep.
- [ ] My code passes current tests and adds new tests where possible.
- [x] My code is [SOLID](https://en.wikipedia.org/wiki/SOLID_(object-oriented_design)) and [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
- [x] I have updated the documentation as needed.

## Reviewer's Checklist:
- [ ] I kept my comments to the author positive, specific, and productive.
- [ ] I tested the code and didn't find any new problems.
- [ ] I think the motivation is good for the project.
- [ ] I think the code works to satisfies the motivation.
