### PR TITLE
changed __tests__/praxis/arthur-deviation-biases/unit.ts to ts

### DIFF
--- a/__tests__/praxis/arthur-deviation-biases/unit.ts
+++ b/__tests__/praxis/arthur-deviation-biases/unit.ts
@@ -33,7 +33,7 @@ describe('ArthurDeviationBiases Class: Unit', () => {
           momentum: 0.2,
         },
       });
-      const result: any = kernel(weights, deltas);
+      const result: Float32Array = kernel(weights, deltas);
       const value = new Float32Array([1.25, 2.20000005, 3.1500001]);
       expect(shave(result)).toEqual(shave(value));
     });

--- a/__tests__/praxis/arthur-deviation-biases/unit.ts
+++ b/__tests__/praxis/arthur-deviation-biases/unit.ts
@@ -1,13 +1,12 @@
-const { GPU } = require('gpu.js');
-const { gpuMock } = require('gpu-mock.js');
-const {
+import { GPU } from 'gpu.js';
+import { gpuMock } from 'gpu-mock.js';
+import {
   ArthurDeviationBiases,
   arthurDeviationBiases,
   update,
-} = require('../../../src/praxis/arthur-deviation-biases');
-const { shave } = require('../../test-utils');
-const { setup, teardown } = require('../../../src/utilities/kernel');
-const { injectIstanbulCoverage } = require('../../test-utils');
+} from '../../../src/praxis/arthur-deviation-biases';
+import { shave, injectIstanbulCoverage } from '../../test-utils';
+import { setup, teardown } from '../../../src/utilities/kernel';
 
 describe('ArthurDeviationBiases Class: Unit', () => {
   beforeEach(() => {
@@ -34,14 +33,16 @@ describe('ArthurDeviationBiases Class: Unit', () => {
           momentum: 0.2,
         },
       });
-      const result = kernel(weights, deltas);
-      expect(shave(result)).toEqual(shave([[1.25, 2.20000005, 3.1500001]]));
+      const result: any = kernel(weights, deltas);
+      const value = new Float32Array([1.25, 2.20000005, 3.1500001]);
+      expect(shave(result)).toEqual(shave(value));
     });
   });
 
   describe('.setupKernels()', () => {
     test('instantiates .kernel', () => {
-      const p = new ArthurDeviationBiases({ width: 2, height: 2 });
+      const mockLayer: any = { width: 2, height: 2 };
+      const p = new ArthurDeviationBiases(mockLayer);
       p.setupKernels();
       expect(p.kernel).not.toBe(null);
     });
@@ -51,16 +52,16 @@ describe('ArthurDeviationBiases Class: Unit', () => {
     it('calls this.kernel() returns kernel output', () => {
       const mockWeights = 1;
       const mockDeltas = 2;
-      const mockLayer = {
+      const mockLayer: any = {
         width: 2,
         height: 2,
         deltas: mockDeltas,
         weights: mockWeights,
       };
-      const p = new ArthurDeviationBiases(mockLayer);
+      const p: any = new ArthurDeviationBiases(mockLayer);
       const mockResult = {};
       p.kernel = jest.fn(() => mockResult);
-      const result = p.run(mockLayer);
+      const result = p.run(mockLayer, NaN);
       expect(result).toBe(mockResult);
       expect(p.kernel).toHaveBeenCalledWith(mockWeights, mockDeltas);
     });
@@ -68,7 +69,7 @@ describe('ArthurDeviationBiases Class: Unit', () => {
 
   describe('arthurDeviationBiases lambda', () => {
     it('creates a new instance of ArthurDeviationBiases', () => {
-      const mockLayer = {};
+      const mockLayer: any = {};
       const p = arthurDeviationBiases(mockLayer);
       expect(p.layerTemplate).toBe(mockLayer);
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- If you don't mind add a fun gif or meme, but no pressure -->
![A GIF or MEME to give some spice of the internet](https://i.redd.it/8xxp8gkq02u21.png)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR is for [issue](https://github.com/BrainJS/brain.js/issues/551) #551 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Author's Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code focuses on the main motivation and avoids scope creep.
- [ ] My code passes current tests and adds new tests where possible.
- [x] My code is [SOLID](https://en.wikipedia.org/wiki/SOLID_(object-oriented_design)) and [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
- [ ] I have updated the documentation as needed.

## Reviewer's Checklist:
- [x] I kept my comments to the author positive, specific, and productive.
- [x] I tested the code and didn't find any new problems.
- [x] I think the motivation is good for the project.
- [x] I think the code works to satisfies the motivation.
