### PR TITLE
Fix CI with Float32Array type cast

### DIFF
--- a/__tests__/praxis/arthur-deviation-biases/unit.ts
+++ b/__tests__/praxis/arthur-deviation-biases/unit.ts
@@ -33,7 +33,7 @@ describe('ArthurDeviationBiases Class: Unit', () => {
           momentum: 0.2,
         },
       });
-      const result: Float32Array = kernel(weights, deltas);
+      const result = kernel(weights, deltas) as Float32Array;
       const value = new Float32Array([1.25, 2.20000005, 3.1500001]);
       expect(shave(result)).toEqual(shave(value));
     });


### PR DESCRIPTION
## Description

Looks like CI was failing, so I changed this faulty declaration to use a type cast. Given it's in the context of a test, this isn't so egregious.

## Motivation and Context

Since the test checks equality, it shouldn't be an issue to cast here.

## How Has This Been Tested?

It's in a test and makes the linter pass 👍 

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Author's Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code focuses on the main motivation and avoids scope creep.
- [x] My code passes current tests and adds new tests where possible.
- [ ] My code is [SOLID](https://en.wikipedia.org/wiki/SOLID_(object-oriented_design)) and [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
- [ ] I have updated the documentation as needed.

## Reviewer's Checklist:
- [ ] I kept my comments to the author positive, specific, and productive.
- [ ] I tested the code and didn't find any new problems.
- [ ] I think the motivation is good for the project.
- [ ] I think the code works to satisfies the motivation.
