### PR TITLE
Update es5 require to es6 import on src folder

### DIFF
--- a/src/layer/rnn-cell.ts
+++ b/src/layer/rnn-cell.ts
@@ -1,11 +1,10 @@
 import { ILayer, ILayerSettings } from './base-layer';
 import { RecurrentZeros } from './recurrent-zeros';
-
-const { relu } = require('./relu');
-const { add } = require('./add');
-const { multiply } = require('./multiply');
-const { random } = require('./random');
-const { zeros } = require('./zeros');
+import { relu } from './relu';
+import { add } from './add';
+import { multiply } from './multiply';
+import { random } from './random';
+import { zeros } from './zeros';
 
 export function rnnCell(
   settings: ILayerSettings,

--- a/src/recurrent/matrix/clone.ts
+++ b/src/recurrent/matrix/clone.ts
@@ -3,8 +3,9 @@ import { Matrix } from '.';
 /**
  *
  * @param {Matrix} product
+ * @return {Matrix}
  */
-module.exports = function clone(product: Matrix) {
+function clone(product: Matrix): Matrix {
   const cloned = new Matrix();
 
   cloned.rows = product.rows;
@@ -13,4 +14,6 @@ module.exports = function clone(product: Matrix) {
   cloned.deltas = product.deltas.slice(0);
 
   return cloned;
-};
+}
+
+export default clone;

--- a/src/recurrent/matrix/copy.ts
+++ b/src/recurrent/matrix/copy.ts
@@ -1,13 +1,15 @@
 import { Matrix } from '.';
 
-/*
+/**
  *
  * @param {Matrix} product
  * @param {Matrix} left
  */
-module.exports = function copy(product: Matrix, left: Matrix) {
+function copy(product: Matrix, left: Matrix): void {
   product.rows = left.rows;
   product.columns = left.columns;
   product.weights = left.weights.slice(0);
   product.deltas = left.deltas.slice(0);
-};
+}
+
+export default copy;

--- a/src/recurrent/matrix/sample-i.ts
+++ b/src/recurrent/matrix/sample-i.ts
@@ -1,6 +1,5 @@
 import { Matrix } from '.';
-
-const { randomFloat } = require('../../utilities/random');
+import { randomFloat } from '../../utilities/random';
 
 /**
  *

--- a/src/utilities/randos.ts
+++ b/src/utilities/randos.ts
@@ -1,5 +1,5 @@
-const { randomWeight } = require('./random-weight');
-const { randomFloat } = require('./random');
+import { randomWeight } from './random-weight';
+import { randomFloat } from './random';
 
 /**
  * Returns an array of given size, full of randomness


### PR DESCRIPTION
Basically, to keep an harmonized codebase I switched `require` calls to `import` from ES6 instead

## Description
This code doesn't fix anything other than keeping codebase equal.

## Motivation and Context
- It doesn't solve any issue but keep things organized

## How Has This Been Tested?
- First of all `npm run lint` to remove some warnings and second `npm run build` to guarantee it is not adding any issues

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Author's Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code focuses on the main motivation and avoids scope creep.
- [ ] My code passes current tests and adds new tests where possible.
- [ ] My code is [SOLID](https://en.wikipedia.org/wiki/SOLID_(object-oriented_design)) and [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
- [ ] I have updated the documentation as needed.

## Reviewer's Checklist:
- [x] I kept my comments to the author positive, specific, and productive.
- [x] I tested the code and didn't find any new problems.
- [x] I think the motivation is good for the project.
- [x] I think the code works to satisfies the motivation.
