### PR TITLE
migrate examples/javascript/predict-tense.js to examples/typescript/predict-tense.ts

### DIFF
--- a/examples/typescript/predict-tense.ts
+++ b/examples/typescript/predict-tense.ts
@@ -1,0 +1,53 @@
+import { brain } from '../../src';
+
+// create configuration for training
+const config = {
+  iterations: 15000,
+  log: true,
+  logPeriod: 500,
+  layers: [10],
+};
+
+// create data which will be used for training
+const data = [
+  { input: 'I will write a book.', output: 'future' },
+  { input: 'He will be writing a book.', output: 'future' },
+  { input: 'They will have written the book.', output: 'future' },
+  { input: 'I will not cry.', output: 'future' },
+  { input: 'You will find happiness', output: 'future' },
+  { input: 'I am about to leave.', output: 'future' },
+  { input: 'Will you go out?', output: 'future' },
+  { input: 'I shall leave.', output: 'future' },
+  { input: 'We will rock you.', output: 'future' },
+  { input: 'I shall bring the laptop.', output: 'future' },
+
+  { input: 'Will Smith was late.', output: 'past' },
+  { input: 'I had been to that place.', output: 'past' },
+  { input: 'I was selfish.', output: 'past' },
+  { input: 'We had money.', output: 'past' },
+  { input: 'You were so young!', output: 'past' },
+  { input: 'It was the best day.', output: 'past' },
+  { input: 'What were you saying?', output: 'past' },
+  { input: 'I had been to London.', output: 'past' },
+  { input: 'I should not have left.', output: 'past' },
+  { input: 'What was I thinking?', output: 'past' },
+
+  { input: 'I am here.', output: 'present' },
+  { input: 'Are you eating regularly?', output: 'present' },
+  { input: 'Let me in.', output: 'present' },
+  { input: 'I am running.', output: 'present' },
+  { input: 'Please stop screaming.', output: 'present' },
+  { input: 'I cannot help you', output: 'present' },
+  { input: 'Obey the rules.', output: 'present' },
+  { input: 'Call me a lawyer.', output: 'present' },
+  { input: 'Am I wrong?', output: 'present' },
+  { input: 'Right this way.', output: 'present' },
+];
+
+// the thing we would test
+const test = 'Will you be my friend?';
+
+const network = new brain.recurrent.LSTM();
+network.train(data, config);
+const output = network.run(test);
+console.log(`Tense: ${output}`);


### PR DESCRIPTION
Creates an equivalent typescript example for the existing javascript predict-tense example

## Description
Copied the examples/javascript/predict-tense.js file to examples/typescript/predict-tense.ts and fixed import format.

## Motivation and Context
This is part of a migration to typescript covered by issue [#551](https://github.com/BrainJS/brain.js/issues/551)

## How Has This Been Tested?
Ran the linter and compiled the file with the tsc binary in node_modules

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Author's Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code focuses on the main motivation and avoids scope creep.
- [x] My code passes current tests and adds new tests where possible.
- [x] My code is [SOLID](https://en.wikipedia.org/wiki/SOLID_(object-oriented_design)) and [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
- [x] I have updated the documentation as needed.

## Reviewer's Checklist:
- [ ] I kept my comments to the author positive, specific, and productive.
- [ ] I tested the code and didn't find any new problems.
- [ ] I think the motivation is good for the project.
- [ ] I think the code works to satisfies the motivation.
