### PR TITLE
Import fix for thaw.js

### DIFF
--- a/src/neural-network.ts
+++ b/src/neural-network.ts
@@ -1,5 +1,5 @@
 import { KernelOutput } from 'gpu.js';
-import { Thaw } from 'thaw.js';
+import { Thaw } from 'thaw.js/dist';
 import { ITrainingStatus } from './feed-forward';
 import { InputOutputValue, INumberHash, lookup } from './lookup';
 import {


### PR DESCRIPTION
Import fix for thaw.js

## Description
Import fix which helps to resolve the issue in topic https://github.com/BrainJS/brain.js/issues/614

## Motivation and Context
The async training of neural network is failing in web browser with the follow message

```
TypeError: _thaw2.default is not a constructor
 in brain.js/dist/neural-network.js — line 599
```

## How Has This Been Tested?
It works in my pet project)

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/19227776/110337738-50145b00-8037-11eb-98ad-b5a3eb9eb513.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Author's Checklist:
- [x] My code focuses on the main motivation and avoids scope creep.
- [x] My code passes current tests and adds new tests where possible.
- [x] My code is [SOLID](https://en.wikipedia.org/wiki/SOLID_(object-oriented_design)) and [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
- [x] I have updated the documentation as needed.

## Reviewer's Checklist:
- [ ] I kept my comments to the author positive, specific, and productive.
- [ ] I tested the code and didn't find any new problems.
- [ ] I think the motivation is good for the project.
- [ ] I think the code works to satisfies the motivation.
