### PR TITLE
doc: Fix the broken contribute link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,7 +695,7 @@ Source for `brain.js.org` is available at [Brain.js.org Repository](https://gith
 
 ## Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
+This project exists thanks to all the people who contribute. [[Contribute](/.github/CONTRIBUTING.md)].
 <a href="https://github.com/BrainJS/brain.js/graphs/contributors"><img src="https://opencollective.com/brainjs/contributors.svg?width=890&button=false" /></a>
 
 ## Backers


### PR DESCRIPTION
## Description
Point the contribute link in the README to the correct path.

Fix #706

## Motivation and Context
Fix the broken link to make contributions to the project (a bit) easier.

[issue](https://github.com/BrainJS/brain.js/issues/706)

## How Has This Been Tested?
1. Go to the README
2. Click on the [Contribute] link

## Screenshots (if appropriate):
N/A

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Author's Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code focuses on the main motivation and avoids scope creep.
- [X] My code passes current tests and adds new tests where possible.
- [X] My code is [SOLID](https://en.wikipedia.org/wiki/SOLID_(object-oriented_design)) and [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
- [X] I have updated the documentation as needed.

## Reviewer's Checklist:
- [ ] I kept my comments to the author positive, specific, and productive.
- [ ] I tested the code and didn't find any new problems.
- [ ] I think the motivation is good for the project.
- [ ] I think the code works to satisfies the motivation.
