### PR TITLE
#787 fix: Ensure isSetup is set

### DIFF
--- a/src/utilities/data-formatter.test.ts
+++ b/src/utilities/data-formatter.test.ts
@@ -1,6 +1,31 @@
 import { DataFormatter } from './data-formatter';
 
 describe('DataFormatter', () => {
+  describe('.fromJSON()', () => {
+    const df1 = new DataFormatter('a'.split(''));
+    const json = df1.toJSON();
+    const df2 = DataFormatter.fromJSON(json);
+    it('sets .indexTable from JSON and matches ', () => {
+      expect(df2.indexTable).toEqual({ a: 0, unrecognized: 1 });
+      expect(df2.indexTable).toEqual(df1.indexTable);
+    });
+    it('sets .characterTable from JSON', () => {
+      expect(df2.characterTable).toEqual({ '0': 'a', '1': null });
+      expect(df2.characterTable).toEqual(df1.characterTable);
+    });
+    it('sets .characters from JSON', () => {
+      expect(df2.characters).toEqual(['a', 'unrecognized']);
+      expect(df2.characters).toEqual(df1.characters);
+    });
+    it('sets .specialIndexes from JSON', () => {
+      expect(json.specialIndexes).toEqual([1]);
+      expect(df1.specialIndexes).toEqual(df1.specialIndexes);
+    });
+    it('sets .isSetup from JSON', () => {
+      expect(df2.isSetup).toEqual(true);
+      expect(df2.isSetup).toEqual(df1.isSetup);
+    });
+  });
   test('does not have zeros', () => {
     const dataFormatter = new DataFormatter(
       'abcdefghijklmnopqrstuvwxyz'.split('')

--- a/src/utilities/data-formatter.ts
+++ b/src/utilities/data-formatter.ts
@@ -327,6 +327,7 @@ export class DataFormatter implements IDataFormatter {
     dataFormatter.values = json.values;
     dataFormatter.characters = json.characters;
     dataFormatter.specialIndexes = json.specialIndexes;
+    dataFormatter.isSetup = true;
     return dataFormatter;
   }
 


### PR DESCRIPTION
On DataFormatter it was missing with .fromJSON()
Added tests as well

<!--- Provide a general summary of your changes in the Title above -->

<!-- If you don't mind add a fun gif or meme, but no pressure -->
![A GIF or MEME to give some spice of the internet](https://media0.giphy.com/media/Q8Dubr4o23mSc/giphy.gif?cid=ecf05e47f2q5bcs19emec5lejp6l1fmg8b98sv9zvfhc75f6&rid=giphy.gif&ct=g)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[issue](https://github.com/BrainJS/brain.js/issues/787)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Author's Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code focuses on the main motivation and avoids scope creep.
- [x] My code passes current tests and adds new tests where possible.
- [x] My code is [SOLID](https://en.wikipedia.org/wiki/SOLID_(object-oriented_design)) and [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
- [ ] I have updated the documentation as needed.

## Reviewer's Checklist:
- [x] I kept my comments to the author positive, specific, and productive.
- [x] I tested the code and didn't find any new problems.
- [x] I think the motivation is good for the project.
- [x] I think the code works to satisfies the motivation.
