### PR TITLE
fix: update crossvalidation examples

### DIFF
--- a/examples/javascript/cross-validate.js
+++ b/examples/javascript/cross-validate.js
@@ -23,7 +23,7 @@ const trainingOptions = {
   log: (details) => console.log(details),
 };
 
-const crossValidate = new brain.CrossValidate(brain.NeuralNetwork, netOptions);
+const crossValidate = new brain.CrossValidate(() => new brain.NeuralNetwork(netOptions));
 const stats = crossValidate.train(trainingData, trainingOptions);
 console.log(stats);
 const net = crossValidate.toNeuralNetwork();

--- a/examples/typescript/cross-validate.ts
+++ b/examples/typescript/cross-validate.ts
@@ -25,7 +25,7 @@ const trainingOptions = {
   log: (details: any) => console.log(details),
 };
 
-const crossValidate = new brain.CrossValidate(brain.NeuralNetwork, netOptions);
+const crossValidate = new brain.CrossValidate(() => new brain.NeuralNetwork(netOptions));
 const stats = crossValidate.train(trainingData, trainingOptions);
 console.log(stats);
 const net = crossValidate.toNeuralNetwork();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Current cross validation examples do not work correctly

## Description
<!--- Describe your changes in detail -->
The previous example of initializing a cross validation is outdated i.e `const crossValidate = new brain.CrossValidate(new brain.NeuralNetwork, netOptions);`

When you run the example code with the above, you run into an error - 
```javascript
 const classifier = this.initClassifier();
                                ^

TypeError: this.initClassifier is not a function
```

The new way to initialize a cross validate is
`const crossValidate = new brain.CrossValidate(() => new brain.NeuralNetwork(netOptions));`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change helps devs following the documentation and example of cross validation 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)

## Author's Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation as needed.

## Reviewer's Checklist:
- [ ] I tested the code and didn't find any new problems.
