### PR TITLE
fix error cannot find module.

### DIFF
--- a/rollup.config.browser.js
+++ b/rollup.config.browser.js
@@ -2,7 +2,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
-import { fileURLToPath } from 'node:url';
+// import { fileURLToPath } from 'node:url';
 
 const name = 'brain';
 const extensions = ['.js', '.json', '.node', '.ts'];
@@ -14,9 +14,13 @@ export default {
   // Specify here external modules which you don't want to include in your bundle (for instance: 'lodash', 'moment' etc.)
   // https://rollupjs.org/guide/en#external-e-external
   external: [
-    fileURLToPath(
-      new URL('./node_modules/gpu.js/src/index.js', import.meta.url)
-    ),
+    // brain js already uses gpu.js as peer dependencies so it shouldn't be like this
+    // fileURLToPath(
+    //   new URL('./node_modules/gpu.js/src/index.js', import.meta.url)
+    // ),
+    
+    // But this
+    'gpu.js'
   ],
 
   plugins: [

--- a/rollup.config.browser.js
+++ b/rollup.config.browser.js
@@ -2,7 +2,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
-// import { fileURLToPath } from 'node:url';
+import { fileURLToPath } from 'node:url';
 
 const name = 'brain';
 const extensions = ['.js', '.json', '.node', '.ts'];
@@ -15,12 +15,9 @@ export default {
   // https://rollupjs.org/guide/en#external-e-external
   external: [
     // brain js already uses gpu.js as peer dependencies so it shouldn't be like this
-    // fileURLToPath(
-    //   new URL('./node_modules/gpu.js/src/index.js', import.meta.url)
-    // ),
-    
-    // But this
-    'gpu.js'
+    fileURLToPath(
+      new URL('./node_modules/gpu.js/src/index.js', import.meta.url)
+    ),
   ],
 
   plugins: [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@ import json from '@rollup/plugin-json';
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import * as pkg from './package.json';
-import { fileURLToPath } from 'node:url';
+// import { fileURLToPath } from 'node:url';
 
 const extensions = ['.js', '.json', '.node', '.ts'];
 
@@ -13,9 +13,13 @@ export default {
   // Specify here external modules which you don't want to include in your bundle (for instance: 'lodash', 'moment' etc.)
   // https://rollupjs.org/guide/en#external-e-external
   external: [
-    fileURLToPath(
-      new URL('./node_modules/gpu.js/src/index.js', import.meta.url)
-    ),
+    // brain js already uses gpu.js as peer dependencies so it shouldn't be like this
+    // fileURLToPath(
+    //   new URL('./node_modules/gpu.js/src/index.js', import.meta.url)
+    // ),
+    
+    // But this
+    'gpu.js'
   ],
 
   plugins: [


### PR DESCRIPTION
fix #885 

<!--- Provide a general summary of your changes in the Title above -->

<!-- If you don't mind add a fun gif or meme, but no pressure -->


## Description
<!--- Describe your changes in detail -->
fix eror cannot find module.
that error because when bran.js set gpu.js as peer dependecies. its not installed in our path. but,in user

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[issue](https://github.com/BrainJS/brain.js/issues/###)

## How Has This Been Tested?
i only change external rollup setting
- [x] test for nodejs script
- [x] test for browser

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/33781288/227822351-b9e319d8-4f44-4bd6-8023-e42858a710b4.png)
![image](https://user-images.githubusercontent.com/33781288/230702584-517a7f19-3bec-4eb5-9059-453a58e2496c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Author's Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code focuses on the main motivation and avoids scope creep.

## Reviewer's Checklist:
- [x] I kept my comments to the author positive, specific, and productive.
- [x] I tested the code and didn't find any new problems.
- [ ] I think the motivation is good for the project.
- [ ] I think the code works to satisfies the motivation.
